### PR TITLE
Getting rid of relative paths

### DIFF
--- a/fb_conversions.php
+++ b/fb_conversions.php
@@ -45,6 +45,6 @@ $url = "https://graph.facebook.com/v12.0/{Pixel ID}/events";
 
 // ------------------------------------------------
 // Use cURL to send the POST request
-include './inc/objects/curl.class.php';
+include $_SERVER['DOCUMENT_ROOT'] . "/facebook_conversions-master/inc/objects/curl.class.php";
 $_curl_ = new CurlServer();
 $_curl_->post_request($url, $submitJson);

--- a/inc/objects/curl.class.php
+++ b/inc/objects/curl.class.php
@@ -28,7 +28,7 @@ class CurlServer
 
         // Debug
         //print_r ( $server_output );
-        print_r($serverReponseObject);
+        //print_r($serverReponseObject);
     }
     function get_request($url)
     {
@@ -43,6 +43,6 @@ class CurlServer
 
         // Debug
         //print_r ( $server_output );
-        print_r($serverReponseObject);
+        //print_r($serverReponseObject);
     }
 }


### PR DESCRIPTION
I'm just sharing the changes I did myself to get this code working well for me. This won't work on localhost - this version get's rid of relative paths and comments out code that is only used for debugging. Reason: If I want to send a browser event for Facebook such as "PageView" I'll have to call the fb_conversions.php file from every single page on my website. That means that the use of a relative path to call curl.class.php inside the fb_conversions.php file will surely result in errors. I made this change specifically to get this working on Wordpress - you need to use absolute paths if you want to call the fb_conversions.php inside the functions.php file. I have the fb_conversions.php on my public_html folder, but I guess you can get away with using relative paths if you store this code inside of the themes/EXAMPLE_THEME folder.